### PR TITLE
fix: use subprocess instead of os.system in nanopb_build.py

### DIFF
--- a/AppThreadGroup/project_watch/app_third/lib_nanopb/nanopb_build.py
+++ b/AppThreadGroup/project_watch/app_third/lib_nanopb/nanopb_build.py
@@ -20,7 +20,7 @@ def nanopb_recuse_build(path) -> None:
            #if item.split('.')[-1] == 'proto' and item.split('.')[0] != 'descriptor' and item.split('.')[0] != 'nanopb':
                 # print(compile + execute + path + '\\' + item)
                 print(item)
-                os.system(compile + execute + path + '\\' + item)
+                __import__('subprocess').run([compile.strip()] + execute.split() + [os.path.join(path, item)], shell=False)
         if os.path.isdir(path + '\\' + item):
             nanopb_recuse_build(path + '\\' + item)
 


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `AppThreadGroup/project_watch/app_third/lib_nanopb/nanopb_build.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `AppThreadGroup/project_watch/app_third/lib_nanopb/nanopb_build.py:23` |

**Description**: The nanopb build script constructs a shell command by concatenating the variables 'compile', 'execute', 'path', and 'item' using string concatenation, then passes the result directly to os.system(). The 'path' and 'item' variables are derived from directory enumeration (e.g., os.listdir) and potentially command-line arguments. Because os.system() invokes a shell to interpret the command string, any shell metacharacters present in 'path' or 'item' (such as semicolons, ampersands, backticks, or pipe characters) will be interpreted and executed by the shell.

## Changes
- `AppThreadGroup/project_watch/app_third/lib_nanopb/nanopb_build.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed
